### PR TITLE
Order crud

### DIFF
--- a/app/api/endpoints/item.py
+++ b/app/api/endpoints/item.py
@@ -23,7 +23,7 @@ async def post_item(
             detail="Only users with vendor role can create a item",
         )
 
-    return await item_model.create_item(item, current_user.id)
+    return await item_model.create_item(item, current_user.entity_id)
 
 
 @router.get("/all", response_model=list[Item])
@@ -38,7 +38,6 @@ async def get_item(item_id: str) -> Item:
 
 @router.put("/deactivate/{item_id}")
 async def deactivate_item(item_id: str, current_user: Annotated[User, Depends(get_current_user)]):
-
     if current_user.entity_id is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/app/api/endpoints/order.py
+++ b/app/api/endpoints/order.py
@@ -1,0 +1,159 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Body, Depends, HTTPException, status
+
+from app.api.endpoints.user import get_current_user
+from app.models.item import item_model
+from app.models.order import order_model
+from app.models.volunteer import volunteer_model
+from app.schemas.order import CreateOrderRequest, Order, UpdateOrderRequest
+from app.schemas.user import User, UserType
+
+router = APIRouter()
+
+
+@router.post("/new", response_model=Order)
+async def create_order(
+    order: Annotated[CreateOrderRequest, Body(...)],
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> Order:
+    if current_user.user_type != UserType.VOLUNTEER:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Only volunteers can place orders"
+        )
+
+    if current_user.entity_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="You must be associated with a volunteer profile to place orders",
+        )
+
+    await item_model.get_item(order.item_id)
+    return await order_model.create_order(order, current_user.entity_id)
+
+
+@router.get("/all", response_model=list[Order])
+async def get_all_orders(current_user: Annotated[User, Depends(get_current_user)]) -> list[Order]:
+    if current_user.user_type != UserType.ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Only admins can view all orders"
+        )
+    return await order_model.get_all_orders()
+
+
+@router.get("/{order_id}", response_model=Order)
+async def get_order_by_id(
+    order_id: str,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> Order:
+    order = await order_model.get_order_by_id(order_id)
+
+    if current_user.user_type == UserType.VOLUNTEER:
+        if current_user.entity_id != order.volunteer_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You can can only view your own orders",
+            )
+    elif current_user.user_type == UserType.VENDOR:
+        item = await item_model.get_item(order.item_id)
+        if current_user.entity_id != item.vendor_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You can only view orders for your own items",
+            )
+    elif current_user.user_type != UserType.ADMIN:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    return order
+
+
+@router.get("/item/{item_id}", response_model=list[Order])
+async def get_orders_by_item_id(
+    item_id: str,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> list[Order]:
+    item = await item_model.get_item(item_id)
+    if current_user.user_type == UserType.VENDOR:
+        if current_user.entity_id != item.vendor_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You can only view orders for your own items",
+            )
+    elif current_user.user_type != UserType.ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only admins and vendors can view orders by item",
+        )
+
+    return await order_model.get_orders_by_item_id(item_id)
+
+
+@router.get("/volunteer/{volunteer_id}", response_model=list[Order])
+async def get_orders_by_volunteer_id(
+    volunteer_id: str,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> list[Order]:
+    volunteer = await volunteer_model.get_volunteer_by_id(volunteer_id)
+    if not volunteer:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Volunteer not found")
+
+    if current_user.user_type == UserType.VOLUNTEER:
+        if current_user.entity_id != volunteer_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="You can only view your own orders"
+            )
+    elif current_user.user_type != UserType.ADMIN:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    return await order_model.get_orders_by_volunteer_id(volunteer_id)
+
+
+@router.put("/{order_id}", response_model=Order)
+async def update_order_status(
+    order_id: str,
+    order_update: Annotated[UpdateOrderRequest, Body(...)],
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> Order:
+    """Update order status"""
+    order = await order_model.get_order_by_id(order_id)
+    if current_user.user_type == UserType.VOLUNTEER:
+        if current_user.entity_id != order.volunteer_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="You can only update your own orders"
+            )
+    elif current_user.user_type == UserType.VENDOR:
+        item = await item_model.get_item(order.item_id)
+        if current_user.entity_id != item.vendor_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You can only update orders for your own items",
+            )
+    elif current_user.user_type != UserType.ADMIN:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    return await order_model.update_order_status(order_id, order_update)
+
+
+@router.delete("/{order_id}", response_model=Order)
+async def cancel_order(
+    order_id: str,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> Order:
+    order = await order_model.get_order_by_id(order_id)
+
+    if current_user.user_type == UserType.VOLUNTEER:
+        if current_user.entity_id != order.volunteer_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="You can only cancel your own orders"
+            )
+    elif current_user.user_type == UserType.VENDOR:
+        item = await item_model.get_item(order.item_id)
+        if current_user.entity_id != item.vendor_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You can only cancel orders for your own items",
+            )
+    elif current_user.user_type != UserType.ADMIN:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    return await order_model.cancel_order(order_id)

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from app.api.endpoints import (
     event,
     health,
     item,
+    order,
     organization,
     registration,
     user,
@@ -45,3 +46,5 @@ app.include_router(event.router, prefix="/event", tags=["event"])
 app.include_router(volunteer.router, prefix="/volunteer", tags=["volunteer"])
 
 app.include_router(registration.router, prefix="/registration", tags=["registration"])
+
+app.include_router(order.router, prefix="/order", tags=["order"])

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -1,0 +1,71 @@
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from bson import ObjectId
+from fastapi import HTTPException, status
+
+from app.database.mongodb import db
+from app.schemas.order import CreateOrderRequest, Order, OrderStatus, UpdateOrderRequest
+
+if TYPE_CHECKING:
+    from motor.motor_asyncio import AsyncIOMotorCollection
+
+
+class OrderModel:
+    def __init__(self):
+        self.collection: AsyncIOMotorCollection = db["orders"]
+
+    async def get_order_by_id(self, order_id: str) -> Order:
+        order = await self.collection.find_one({"_id": ObjectId(order_id)})
+        return self._to_order(order) if order else None
+
+    async def get_all_orders(self) -> list[Order]:
+        orders_list = await self.collection.find().to_list(length=None)
+        return [self._to_order(order) for order in orders_list]
+
+    async def get_orders_by_item_id(self, item_id: str) -> list[Order]:
+        orders_list = await self.collection.find({"item_id": ObjectId(item_id)}).to_list(
+            length=None
+        )
+        return [self._to_order(order) for order in orders_list]
+
+    async def get_orders_by_volunteer_id(self, volunteer_id: str) -> list[Order]:
+        orders_list = await self.collection.find({"volunteer_id": ObjectId(volunteer_id)}).to_list(
+            length=None
+        )
+        return [self._to_order(order) for order in orders_list]
+
+    async def create_order(self, order: CreateOrderRequest, volunteer_id: str) -> Order:
+        order_data = {
+            "item_id": ObjectId(order.item_id),
+            "volunteer_id": ObjectId(volunteer_id),
+            "placed_at": datetime.now(),
+            "order_status": OrderStatus.PENDING_PICKUP,
+        }
+
+        result = await self.collection.insert_one(order_data)
+        inserted_doc = await self.collection.find_one({"_id": result.inserted_id})
+
+        return self._to_order(inserted_doc)
+
+    async def update_order_status(self, order_update: UpdateOrderRequest, order_id: str) -> Order:
+        update_data = order_update.model_dump(exclude_unset=True)
+        result = await self.collection.update_one({"_id": order_id}, {"$set": update_data})
+
+        if result.matched_count == 0:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Order not found")
+
+        updated_doc = await self.collection.find_one({"_id": ObjectId(order_id)})
+        return self._to_order(updated_doc)
+
+    async def cancel_order(self, order_id: str):
+        await self.collection.update_one(
+            {"_id": ObjectId(order_id)}, {"$set": {"order_status": False}}
+        )
+
+    def _to_order(self, doc) -> Order:
+        order_data = doc.copy()
+        order_data["id"] = str(order_data["_id"])
+        order_data["item_id"] = str(order_data["item_id"])
+        order_data["volunteer_id"] = str(order_data["volunteer_id"])
+        return Order(**order_data)

--- a/app/schemas/order.py
+++ b/app/schemas/order.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class OrderStatus(str, Enum):
+    PENDING_PICKUP = "pending pickup"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+
+
+class Order(BaseModel):
+    id: str
+    item_id: str
+    volunteer_id: str
+    placed_at: datetime
+    order_status: OrderStatus
+
+    class Config:
+        from_attributes = True
+
+
+class CreateOrderRequest(BaseModel):
+    item_id: str
+
+
+class UpdateOrderRequest(BaseModel):
+    order_status: OrderStatus

--- a/app/services/order.py
+++ b/app/services/order.py
@@ -30,20 +30,3 @@ class OrderService:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
 
         return order
-
-    async def authorize_volunteer_orders_access(
-        self, volunteer_id: str, current_user: User
-    ) -> None:
-        """
-        Authorize access to view orders for a specific volunteer:
-        - Volunteers can only view their own orders
-        - Admins can view any volunteer's orders
-        """
-        if current_user.user_type == UserType.VOLUNTEER:
-            if current_user.entity_id != volunteer_id:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="You can only view your own orders",
-                )
-        elif current_user.user_type != UserType.ADMIN:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")

--- a/app/services/order.py
+++ b/app/services/order.py
@@ -1,0 +1,49 @@
+from fastapi import HTTPException, status
+
+from app.models.item import item_model
+from app.models.order import order_model
+from app.schemas.order import Order
+from app.schemas.user import User, UserType
+
+
+class OrderService:
+    def __init__(self, model=order_model):
+        self.model = model
+
+    async def authorize_order_access(self, order_id: str, current_user: User) -> Order:
+        order = await self.model.get_order_by_id(order_id)
+
+        if current_user.user_type == UserType.VOLUNTEER:
+            if current_user.entity_id != order.volunteer_id:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="You can only access your own orders",
+                )
+        elif current_user.user_type == UserType.VENDOR:
+            item = await item_model.get_item(order.item_id)
+            if current_user.entity_id != item.vendor_id:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="You can only access orders for your own items",
+                )
+        elif current_user.user_type != UserType.ADMIN:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+        return order
+
+    async def authorize_volunteer_orders_access(
+        self, volunteer_id: str, current_user: User
+    ) -> None:
+        """
+        Authorize access to view orders for a specific volunteer:
+        - Volunteers can only view their own orders
+        - Admins can view any volunteer's orders
+        """
+        if current_user.user_type == UserType.VOLUNTEER:
+            if current_user.entity_id != volunteer_id:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="You can only view your own orders",
+                )
+        elif current_user.user_type != UserType.ADMIN:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")


### PR DESCRIPTION
# Description

[Link to Ticket](https://github.com/GenerateNU/karp-backend/issues/17)

Implements the following CRUD operations for the Order entity:
- `POST /order/new` - Create order (volunteers only, defaults to "pending pickup")
- `GET /order/all` - Get all orders (admins only)
- `GET /order/{order_id}` - Get order by ID (with role-based access)
- `GET /order/item/{item_id}` - Get orders for specific item (vendors for own items, admins)
- `GET /order/volunteer/{volunteer_id}` - Get orders for specific volunteer (own orders only)
- `PUT /order/{order_id}` - Update order status
- `DELETE /order/{order_id} `- Cancel order (soft delete to "cancelled" status)
There was (what I think is) a bug/inconsistency in the item creation where vendor_id was set to the user id instead of user.entity_id, which was initially causing authorization failures in the order endpoints. I changed it to set the vendor_id for an item to user.entity_id to make it more consistent to what I've seen in other parts of the code, but if this is incorrect, let me know and I will change it back and then change my order endpoints to match this.

# How Has This Been Tested?

<img width="2134" height="1692" alt="ordertest9" src="https://github.com/user-attachments/assets/95a665c5-7b04-4ae3-b482-e38d359b1229" />
<img width="2122" height="1690" alt="ordertest8" src="https://github.com/user-attachments/assets/9ae32672-5536-4c83-8fcc-e708d001e36b" />
<img width="2140" height="1656" alt="ordertest6" src="https://github.com/user-attachments/assets/0a6a4a0b-b3d7-45c0-b28d-14a483742c00" />
<img width="2136" height="1700" alt="ordertest5" src="https://github.com/user-attachments/assets/d8528ae0-5a9a-4ead-ab83-b39feb14d2a7" />
<img width="2126" height="1380" alt="ordertest4" src="https://github.com/user-attachments/assets/fa40985a-dd07-48f4-b8ad-4ecee9fb1e1a" />
<img width="2138" height="1642" alt="ordertest3" src="https://github.com/user-attachments/assets/889a4df8-ebc5-40a9-9295-3251d85782fb" />
<img width="2130" height="1640" alt="ordertest1" src="https://github.com/user-attachments/assets/498afb66-d2a9-4e41-ba95-9c1613df77d5" />
<img width="2120" height="1636" alt="ordertest11" src="https://github.com/user-attachments/assets/6fea2fe9-f69f-4bd6-9d3f-50c7100ee27b" />
<img width="2162" height="1724" alt="ordertest10" src="https://github.com/user-attachments/assets/b35d6a58-35ff-40b8-87b7-8c11df251fcf" />



# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have reached out to another developer to review my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
