### PR TITLE
Additional volunteer endpoints

### DIFF
--- a/app/api/endpoints/registration.py
+++ b/app/api/endpoints/registration.py
@@ -1,9 +1,13 @@
-from fastapi import APIRouter
+from typing import Annotated
 
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.api.endpoints.user import get_current_user
 from app.models.registration import registration_model
-from app.schemas.registration import (
-    Registration,
-)
+from app.models.volunteer import volunteer_model
+from app.schemas.event import Event
+from app.schemas.registration import Registration
+from app.schemas.user import User, UserType
 
 router = APIRouter()
 
@@ -12,3 +16,45 @@ router = APIRouter()
 @router.get("/event-volunteers/{event_id}", response_model=list[Registration])
 async def get_volunteers_by_event(event_id: str) -> list[Registration]:
     return await registration_model.get_volunteers_by_event(event_id)
+
+
+@router.get("/events/completed/{volunteer_id}", response_model=list[Event])
+async def get_completed_events_by_volunteer(
+    volunteer_id: str,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> list[Event]:
+    volunteer = await volunteer_model.get_volunteer_by_id(volunteer_id)
+    if not volunteer:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Volunteer not found")
+
+    if current_user.user_type == UserType.VOLUNTEER:
+        if current_user.entity_id != volunteer_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="You can only view your own events"
+            )
+
+    elif current_user.user_type != UserType.ADMIN:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    return await registration_model.get_completed_events_by_volunteer(volunteer_id)
+
+
+@router.get("/events/upcoming/{volunteer_id}", response_model=list[Event])
+async def get_upcoming_events_by_volunteer(
+    volunteer_id: str,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> list[Event]:
+    volunteer = await volunteer_model.get_volunteer_by_id(volunteer_id)
+    if not volunteer:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Volunteer not found")
+
+    if current_user.user_type == UserType.VOLUNTEER:
+        if current_user.entity_id != volunteer_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="You can only view your own events"
+            )
+
+    elif current_user.user_type != UserType.ADMIN:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    return await registration_model.get_upcoming_events_by_volunteer(volunteer_id)

--- a/app/api/endpoints/registration.py
+++ b/app/api/endpoints/registration.py
@@ -1,12 +1,12 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app.api.endpoints.user import get_current_user
 from app.models.registration import registration_model
 from app.models.volunteer import volunteer_model
 from app.schemas.event import Event
-from app.schemas.registration import Registration
+from app.schemas.registration import Registration, RegistrationStatus
 from app.schemas.user import User, UserType
 
 router = APIRouter()
@@ -18,10 +18,11 @@ async def get_volunteers_by_event(event_id: str) -> list[Registration]:
     return await registration_model.get_volunteers_by_event(event_id)
 
 
-@router.get("/events/completed/{volunteer_id}", response_model=list[Event])
-async def get_completed_events_by_volunteer(
+@router.get("/events/{volunteer_id}", response_model=list[Event])
+async def get_events_by_volunteer(
     volunteer_id: str,
-    current_user: Annotated[User, Depends(get_current_user)],
+    status: Annotated[RegistrationStatus | None, Query(description="Filter by status")] = None,
+    current_user: Annotated[User, Depends(get_current_user)] = None,
 ) -> list[Event]:
     volunteer = await volunteer_model.get_volunteer_by_id(volunteer_id)
     if not volunteer:
@@ -30,31 +31,10 @@ async def get_completed_events_by_volunteer(
     if current_user.user_type == UserType.VOLUNTEER:
         if current_user.entity_id != volunteer_id:
             raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="You can only view your own events"
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You can only view your own events",
             )
-
     elif current_user.user_type != UserType.ADMIN:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
 
-    return await registration_model.get_completed_events_by_volunteer(volunteer_id)
-
-
-@router.get("/events/upcoming/{volunteer_id}", response_model=list[Event])
-async def get_upcoming_events_by_volunteer(
-    volunteer_id: str,
-    current_user: Annotated[User, Depends(get_current_user)],
-) -> list[Event]:
-    volunteer = await volunteer_model.get_volunteer_by_id(volunteer_id)
-    if not volunteer:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Volunteer not found")
-
-    if current_user.user_type == UserType.VOLUNTEER:
-        if current_user.entity_id != volunteer_id:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="You can only view your own events"
-            )
-
-    elif current_user.user_type != UserType.ADMIN:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
-
-    return await registration_model.get_upcoming_events_by_volunteer(volunteer_id)
+    return await registration_model.get_events_by_volunteer(volunteer_id, status)

--- a/app/models/registration.py
+++ b/app/models/registration.py
@@ -4,9 +4,9 @@ from motor.motor_asyncio import AsyncIOMotorCollection  # noqa: TCH002
 
 from app.database.mongodb import db
 from app.models.event import event_model
-from app.schemas.registration import (
-    Registration,
-)
+from app.models.volunteer import volunteer_model
+from app.schemas.event import Event
+from app.schemas.registration import Registration, RegistrationStatus
 
 
 class RegistrationModel:
@@ -47,6 +47,55 @@ class RegistrationModel:
 
         volunteers_docs = await self.registrations.aggregate(pipeline).to_list(length=None)
         return [self._to_volunteer(volunteer) for volunteer in volunteers_docs]
+
+    async def get_completed_events_by_volunteer(self, volunteer_id: str) -> list[Event]:
+        volunteer = await volunteer_model.get_volunteer_by_id(volunteer_id)
+        if not volunteer:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Volunteer not found")
+        pipeline = [
+            {
+                "$match": {
+                    "volunteer_id": ObjectId(volunteer_id),
+                    "registration_status": RegistrationStatus.COMPLETED,
+                }
+            },
+            {
+                "$lookup": {
+                    "from": "events",
+                    "localField": "event_id",
+                    "foreignField": "_id",
+                    "as": "event_docs",
+                }
+            },
+            {"$unwind": "$event_docs"},
+            {"$replaceRoot": {"newRoot": "$event_docs"}},
+        ]
+
+        event_docs = await self.registrations.aggregate(pipeline).to_list(length=None)
+        return [event_model.to_event(event) for event in event_docs]
+
+    async def get_upcoming_events_by_volunteer(self, volunteer_id: str) -> list[Event]:
+        pipeline = [
+            {
+                "$match": {
+                    "volunteer_id": ObjectId(volunteer_id),
+                    "registration_status": RegistrationStatus.UPCOMING,
+                }
+            },
+            {
+                "$lookup": {
+                    "from": "events",
+                    "localField": "event_id",
+                    "foreignField": "_id",
+                    "as": "event_docs",
+                }
+            },
+            {"$unwind": "$event_docs"},
+            {"$replaceRoot": {"newRoot": "$event_docs"}},
+        ]
+
+        event_docs = await self.registrations.aggregate(pipeline).to_list(length=None)
+        return [event_model.to_event(event) for event in event_docs]
 
     def _to_volunteer(self, doc) -> Registration:
         registration_data = doc.copy()

--- a/app/schemas/registration.py
+++ b/app/schemas/registration.py
@@ -1,12 +1,23 @@
+from datetime import datetime
+from enum import Enum
+
 from pydantic import BaseModel
+
+
+class RegistrationStatus(str, Enum):
+    UPCOMING = "upcoming"
+    COMPLETED = "completed"
+    INCOMPLETED = "incompleted"
 
 
 class Registration(BaseModel):
     id: str
-    first_name: str
-    last_name: str
-    username: str
+    event_id: str
     volunteer_id: str
+    registered_at: datetime
+    registration_status: RegistrationStatus
+    clocked_in: bool
+    clocked_out: bool
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
# Description

[Link to Ticket](https://github.com/GenerateNU/karp-backend/issues/15)

Implemented the following endpoints:
- `GET /registration/events/completed/{volunteer_id}` - Returns events with registration_status "completed"
- `GET /registration/events/upcoming/{volunteer_id}` - Returns events with registration_status "upcoming"

# How Has This Been Tested?

<img width="2126" height="1676" alt="registrationtest4" src="https://github.com/user-attachments/assets/2ba93e1b-afde-4b4b-9982-d2fe94695826" />
<img width="2134" height="1590" alt="registrationtest3" src="https://github.com/user-attachments/assets/a9089cf3-8104-4c84-8643-c34ef42afbe7" />
<img width="2122" height="1616" alt="registrationtest2" src="https://github.com/user-attachments/assets/cc6be63b-8fea-4308-b67f-c01c5496dfc7" />
<img width="2126" height="1606" alt="registrationtest1" src="https://github.com/user-attachments/assets/db214049-dae3-4fbf-8914-54c8c403095d" />

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have reached out to another developer to review my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
