### PR TITLE
28 registration and unregistration

### DIFF
--- a/app/api/endpoints/registration.py
+++ b/app/api/endpoints/registration.py
@@ -21,7 +21,9 @@ async def get_volunteers_by_event(event_id: str) -> list[Registration]:
 @router.get("/events/{volunteer_id}", response_model=list[Event])
 async def get_events_by_volunteer(
     volunteer_id: str,
-    status: Annotated[RegistrationStatus | None, Query(description="Filter by status")] = None,
+    registration_status: Annotated[
+        RegistrationStatus | None, Query(description="Filter by status")
+    ] = None,
     current_user: Annotated[User, Depends(get_current_user)] = None,
 ) -> list[Event]:
     volunteer = await volunteer_model.get_volunteer_by_id(volunteer_id)
@@ -37,7 +39,7 @@ async def get_events_by_volunteer(
     elif current_user.user_type != UserType.ADMIN:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
 
-    return await registration_model.get_events_by_volunteer(volunteer_id, status)
+    return await registration_model.get_events_by_volunteer(volunteer_id, registration_status)
 
 
 @router.post("/new", response_model=Registration)
@@ -57,3 +59,23 @@ async def create_registrion(
         )
 
     return await registration_model.create_registration(registration, current_user.entity_id)
+
+
+@router.put("/unregister/{registration_id}", response_model=Registration)
+async def unregister_registration(
+    registration_id: str,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> Registration:
+    if current_user.user_type != UserType.VOLUNTEER:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only volunteers can unregister from events",
+        )
+
+    if current_user.entity_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="You must be associated with a volunteer profile to unregister from an event",
+        )
+
+    return await registration_model.unregister_registration(registration_id, current_user.entity_id)

--- a/app/schemas/registration.py
+++ b/app/schemas/registration.py
@@ -8,6 +8,7 @@ class RegistrationStatus(str, Enum):
     UPCOMING = "upcoming"
     COMPLETED = "completed"
     INCOMPLETED = "incompleted"
+    UNREGISTERED = "unregistered"
 
 
 class Registration(BaseModel):
@@ -21,3 +22,7 @@ class Registration(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class CreateRegistrationRequest(BaseModel):
+    event_id: str


### PR DESCRIPTION
# Description

[Link to Ticket](https://github.com/GenerateNU/karp-backend/issues/28)

This PR is about users registering and unregistering for events. This is important functionality for the central use of our app. When registering, a new registration is created. When unregistering, that registration is fed in, and gets changed to the status: "unregistered" from "upcoming"

<img width="965" height="746" alt="Screenshot 2025-10-03 at 3 05 45 PM" src="https://github.com/user-attachments/assets/ff5a1d84-bb12-46c6-863e-34d162edeb74" />

<img width="975" height="672" alt="Screenshot 2025-10-05 at 1 18 53 PM" src="https://github.com/user-attachments/assets/ffa78af9-851e-47a4-83dd-1de7d888649a" />


# How Has This Been Tested?

I tried both endpoints on Swagger as a user with the volunteer type

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have reached out to another developer to review my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
